### PR TITLE
Action and Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This GitHub Action sets up Python, Poetry and Just, as well as using Just to install project dependencies, in your workflow.
 
-It should be noted that this Action uses `Python version 3.12` and `Poetry version 1.8.3`.
+It should be noted that, by default, this Action uses `Python version 3.12` and `Poetry version 1.8.3` but you can pass in your preferred version if you don't want ot use the defaults.
 
-## Example workflow
+## Examples
+
+### Workflow using default versions
 
 ```yaml
 name: CI
@@ -16,5 +18,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: cmb84scd/python-action@v1
+      - run: your code
+```
+
+### Workflow passing in Python and Poetry versions
+
+```yaml
+name: CI
+
+on: pull_request
+
+jobs:
+  <job_name>:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cmb84scd/python-action@v1
+        with:
+          poetry-version: 'latest'
+          python-version: '3.10'
       - run: your code
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
-# Python Action
+# Python GitHub Action
 
-This repo contains an action to set up Python, Poetry and Just.
+This GitHub Action sets up Python, Poetry and Just, as well as using Just to install project dependencies, in your workflow.
+
+It should be noted that this Action uses `Python version 3.12` and `Poetry version 1.8.3`.
+
+## Example workflow
+
+```yaml
+name: CI
+
+on: pull_request
+
+jobs:
+  <job_name>:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cmb84scd/python-action@v1
+      - run: your code
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This GitHub Action sets up Python, Poetry and Just, as well as using Just to install project dependencies, in your workflow.
 
-It should be noted that, by default, this Action uses `Python version 3.12` and `Poetry version 1.8.3` but you can pass in your preferred version if you don't want ot use the defaults.
+By default, this Action uses `Python version 3.12` and `Poetry version 1.8.3` but you can pass in a version of your choosing if you prefer.
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
-name: 'Python'
+name: 'Setup Python Poetry Just'
+description: 'An action to setup Python, Poetry and Just plus install project dependencies.'
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,26 @@
 name: 'Setup Python Poetry Just'
 description: 'An action to setup Python, Poetry and Just plus install project dependencies.'
 
+inputs:
+  poetry-version:
+    description: 'The version of poetry to install'
+    required: false
+    default: '1.8.3'
+  python-version:
+    description: 'The version of python to install'
+    required: false
+    default: '3.12'
+
 runs:
   using: 'composite'
   steps:
   - uses: actions/checkout@v4
   - uses: abatilo/actions-poetry@v3
     with:
-      poetry-version: '1.8.3'
+      poetry-version: ${{ inputs.poetry-version }}
   - uses: actions/setup-python@v5
     with:
-      python-version: '3.12'
+      python-version: ${{ inputs.python-version }}
       cache: 'poetry'
   - uses: extractions/setup-just@v2
   - name: install dependencies


### PR DESCRIPTION
I would like to publish this action but it required a few small improvements before doing so. This MR does the following:
- Change the name of the action to better reflect what it does
- Adds a description
- Adds the option to pass in a Python and/or Poetry version
- Enhanced the description in the Readme as well as adding 2 usage examples

I tested the action in another repo, both using the defaults and passing in versions for python/poetry. You can see the pipelines here:
[versions passed in](https://github.com/cmb84scd/animal-fact-api/actions/runs/9779750207)
[defaults used](https://github.com/cmb84scd/animal-fact-api/actions/runs/9665261097)
In both pipelines, it's just the lint job that uses the changes in this MR